### PR TITLE
make lld report error when the object code has relaxation requirement

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -539,7 +539,7 @@ void riscv::getRISCVTargetFeatures(const Driver &D, const llvm::Triple &Triple,
     Features.push_back("+reserve-x31");
 
   // -mrelax is default, unless -mno-relax is specified.
-  if (Args.hasFlag(options::OPT_mrelax, options::OPT_mno_relax, false))
+  if (Args.hasFlag(options::OPT_mrelax, options::OPT_mno_relax, true))
     Features.push_back("+relax");
   else
     Features.push_back("-relax");

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -243,8 +243,8 @@ RelExpr RISCV::getRelExpr(const RelType type, const Symbol &s,
     // Not just a hint; always padded to the worst-case number of NOPs, so may
     // not currently be aligned, and without linker relaxation support we can't
     // delete NOPs to realign.
-    //errorOrWarn(getErrorLocation(loc) + "relocation R_RISCV_ALIGN requires "
-    //            "unimplemented linker relaxation; recompile with -mno-relax");
+    errorOrWarn(getErrorLocation(loc) + "relocation R_RISCV_ALIGN requires "
+                "unimplemented linker relaxation; recompile with -mno-relax");
     return R_NONE;
   default:
     error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +


### PR DESCRIPTION
In the past, the error was disabled and the relaxation requirement was
ignored.